### PR TITLE
Add Nippon

### DIFF
--- a/wap-fr-EN23_Nippon.cat
+++ b/wap-fr-EN23_Nippon.cat
@@ -5036,6 +5036,9 @@
                       <costs>
                         <cost name="pts" typeId="points" value="0"/>
                       </costs>
+                      <modifiers>
+                        <modifier type="set" value="0" field="points"/>
+                      </modifiers>
                     </entryLink>
                   </entryLinks>
                 </entryLink>


### PR DESCRIPTION
The Book has several bugs with the mons.
(they are listed in M's xls)
My intepretations / workarounds:

-Clan Hattiga: no loner or expendable unit can take a clan mon. But Ninja, kabuki and shinobis  (the only benefical units of this clan) are Loner. So they can take only this clan.

-clan Uesigo: ther eare no Shugenja. i gave it to all Onmyoji (wizards). additionally, uesigo norimasa states, that yamabushi and shugenja also need to take this clan mon. so i guess, they are monks too. Sumo warriors state weirdly monks in the command unit, but i assume, this is wrong. 
and finally, uesigo norimase technically does not force you to take the Uesigo clan, as long you don't play any unit of monks. which is stupiud, cause this is kinda his theme.

