### PR TITLE
Hotfix for WoC (and lizards)

### DIFF
--- a/wap-fr-EN23_Lizardmen.cat
+++ b/wap-fr-EN23_Lizardmen.cat
@@ -1906,8 +1906,9 @@ can cause the Mage-Priest to roll more dice than normally allowed.</characteris
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" scope="root-entry"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" scope="root-entry"/>
+            <modifier type="unset-primary" value="b876-2856-f1c2-c4f0" field="category" scope="root-entry" affects="self.entries.recursive"/>
+            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" scope="root-entry" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" scope="root-entry" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="2" field="selections" scope="model-or-unit" childId="38b3-9c61-1d02-936f" shared="true" includeChildSelections="true"/>
@@ -1964,8 +1965,9 @@ can cause the Mage-Priest to roll more dice than normally allowed.</characteris
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" scope="root-entry"/>
-            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" scope="root-entry"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" scope="root-entry" affects="self.entries.recursive"/>
+            <modifier type="unset-primary" value="d280-b7df-c185-2ba5" field="category" scope="root-entry" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" scope="root-entry" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="2" field="selections" scope="model-or-unit" childId="5f61-08f3-48c6-3f54" shared="true" includeChildSelections="true"/>

--- a/wap-fr-EN23_Warriors_of_Chaos.cat
+++ b/wap-fr-EN23_Warriors_of_Chaos.cat
@@ -15416,25 +15416,28 @@ Tamurkhan&apos;s power cannot save him if he is destroyed by an attack which cau
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
-                <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" scope="root-entry"/>
-                <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" scope="root-entry"/>
               </modifiers>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <modifiers>
-        <modifier type="remove" value="0eb4-f376-7725-b05b" field="category">
-          <conditions>
-            <condition type="atLeast" value="1" field="selections" scope="roster" childId="67de-5882-a257-da2e" shared="true" includeChildSelections="true" includeChildForces="true"/>
-          </conditions>
-        </modifier>
-        <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category">
-          <conditions>
-            <condition type="atLeast" value="1" field="selections" scope="roster" childId="67de-5882-a257-da2e" shared="true" includeChildSelections="true" includeChildForces="true"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="roster" childId="67de-5882-a257-da2e" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="476b-56ed-5973-3b8c" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+          <modifiers>
+            <modifier type="unset-primary" value="0eb4-f376-7725-b05b" field="category"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
     </entryLink>
     <entryLink import="true" name="War Chariot" hidden="false" id="521d-8f6e-b972-4479" type="selectionEntry" targetId="8ab9-75cd-5f33-e891" sortIndex="17">
       <costs>


### PR DESCRIPTION
Added a blue info bubble to dragon ogre shaggoth, to point where to swap a unit of dragon ogres to special.
when swapping, i unset primary rare. but i have to remove rare. else it counts still as rare and shows up after going over your point limit. 
Did the same fix for lizardmen and checkted TK. latter where correct.