### PR TITLE
Primary cathegory swap

### DIFF
--- a/wap-fr-EN23_Chaos_Dwarfs.cat
+++ b/wap-fr-EN23_Chaos_Dwarfs.cat
@@ -3228,8 +3228,8 @@
           <modifiers>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="5c30-c07c-7e2f-2bc5" shared="true" includeChildSelections="true" includeChildForces="true"/>

--- a/wap-fr-EN23_Dark_Elves.cat
+++ b/wap-fr-EN23_Dark_Elves.cat
@@ -2826,8 +2826,8 @@
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="equalTo" value="1" field="selections" scope="force" childId="1161-1d69-3563-4036" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>

--- a/wap-fr-EN23_High_Elves.cat
+++ b/wap-fr-EN23_High_Elves.cat
@@ -3600,8 +3600,8 @@
           <modifiers>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="equalTo" value="1" field="selections" scope="force" childId="29d0-3d00-ec13-52db" shared="true" includeChildSelections="true"/>
@@ -3826,8 +3826,8 @@
           <modifiers>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="force" childId="d527-804c-d7eb-a958" shared="true" includeChildSelections="true"/>

--- a/wap-fr-EN23_Kislev.cat
+++ b/wap-fr-EN23_Kislev.cat
@@ -3528,8 +3528,8 @@ The enemy may not pursue a unit disengaging from combat in this manner. After m
           <modifiers>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="7b55-0dd1-7735-6577" shared="true" includeChildSelections="true" includeChildForces="true"/>

--- a/wap-fr-EN23_Ogre_Kingdoms.cat
+++ b/wap-fr-EN23_Ogre_Kingdoms.cat
@@ -4532,8 +4532,8 @@ The wearer gains +1 Strength and a Ward save (6+). If a Magic Weapon inflicts a 
           <modifiers>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="fb54-6ecf-d459-17a8" shared="true" includeChildSelections="true" includeChildForces="true">
@@ -6000,8 +6000,8 @@ The wearer gains +1 Strength and a Ward save (6+). If a Magic Weapon inflicts a 
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="fb54-6ecf-d459-17a8" shared="true" includeChildSelections="true" includeChildForces="true">

--- a/wap-fr-EN23_Orcs_Goblins.cat
+++ b/wap-fr-EN23_Orcs_Goblins.cat
@@ -2488,8 +2488,8 @@ Victory Points are rewarded for each slain Fanatic individually.</description>
           <modifiers>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="force" childId="399c-7c07-5374-3702" shared="true" includeChildSelections="true"/>

--- a/wap-fr-EN23_The_Empire.cat
+++ b/wap-fr-EN23_The_Empire.cat
@@ -3409,9 +3409,9 @@
         <modifierGroup type="and">
           <modifiers>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
-            <modifier type="add" value="fc26-7737-f7cb-8977" field="category"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="add" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="equalTo" value="1" field="selections" scope="force" childId="9d22-a8fc-1673-bc03" shared="true" includeChildSelections="true"/>

--- a/wap-fr-EN23_Tomb_Kings.cat
+++ b/wap-fr-EN23_Tomb_Kings.cat
@@ -2057,8 +2057,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -2191,8 +2191,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category"/>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
-            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -2296,8 +2296,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category"/>
-            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -2432,8 +2432,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category"/>
-            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -2669,8 +2669,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category"/>
-            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -2795,8 +2795,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -2852,8 +2852,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category"/>
-            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3015,8 +3015,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3077,8 +3077,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3127,8 +3127,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3205,8 +3205,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
           </modifiers>
@@ -3258,8 +3258,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
           </modifiers>
@@ -3317,8 +3317,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
           </modifiers>
@@ -3386,8 +3386,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3464,8 +3464,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3563,8 +3563,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3697,8 +3697,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3777,8 +3777,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3889,8 +3889,8 @@ If, at the start of any of your turns following the death of the Hierophant, the
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -3983,8 +3983,8 @@ Leech from the Lore of Death.</characteristic>
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -4114,8 +4114,8 @@ Strength 2 hits which Ignores Armour saves</description>
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -5521,8 +5521,8 @@ Strength 2 hits which Ignores Armour saves</description>
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category"/>
-            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="remove" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -5673,8 +5673,8 @@ Strength 2 hits which Ignores Armour saves</description>
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
           </modifiers>
@@ -7156,8 +7156,8 @@ move as normal (including declaring charges).</characteristic>
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>
@@ -7177,8 +7177,8 @@ move as normal (including declaring charges).</characteristic>
           <modifiers>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="edd3-38ef-b378-e726" shared="true" includeChildSelections="true" includeChildForces="true"/>

--- a/wap-fr-EN23_Vampire_Counts.cat
+++ b/wap-fr-EN23_Vampire_Counts.cat
@@ -2049,7 +2049,7 @@
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f018-524e-1634-219e"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Nightmare" hidden="false" id="deb6-a20e-9f64-8b95" type="selectionEntry" targetId="288d-c0a8-77de-61e7" sortIndex="4">
+            <entryLink import="true" name="Nightmare" hidden="false" id="deb6-a20e-9f64-8b95" type="selectionEntry" targetId="288d-c0a8-77de-61e7" sortIndex="4" collective="true">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2ead-1e5f-209d-d6b0"/>
               </constraints>
@@ -2118,8 +2118,8 @@
           <modifiers>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="roster" childId="dc78-fd7f-b4f3-5a12" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="true"/>

--- a/wap-fr-EN23_Warriors_of_Chaos.cat
+++ b/wap-fr-EN23_Warriors_of_Chaos.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ce3b-bf93-496e-a65c" name="Warriors of Chaos WAP 1.62" revision="56" battleScribeVersion="2.03" authorName="skalfmarteaunoir" authorContact="Contact me via discord (1st link). See instructions for bug reporting on Github (2nd link)" authorUrl="https://discord.com/invite/AaNyj9s" library="false" gameSystemId="5835-cbeb-a5c6-d13e" gameSystemRevision="56" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="ce3b-bf93-496e-a65c" name="Warriors of Chaos WAP 1.62" revision="57" battleScribeVersion="2.03" authorName="skalfmarteaunoir" authorContact="Contact me via discord (1st link). See instructions for bug reporting on Github (2nd link)" authorUrl="https://discord.com/invite/AaNyj9s" library="false" gameSystemId="5835-cbeb-a5c6-d13e" gameSystemRevision="56" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <readme>https://github.com/sbh427/wap-2.3</readme>
   <profileTypes>
     <profileType id="49dc-2fd8-b942-dbc2" name="Gift of the Gods">
@@ -15478,7 +15478,7 @@ Tamurkhan&apos;s power cannot save him if he is destroyed by an attack which cau
       <modifiers>
         <modifier type="set" value="1" field="85f8-a8e2-7e92-cfd2">
           <conditions>
-            <condition type="equalTo" value="1" field="selections" scope="force" childId="a696-9ce8-c2ba-5461" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+            <condition type="equalTo" value="1" field="selections" scope="roster" childId="a696-9ce8-c2ba-5461" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="true"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -15487,11 +15487,11 @@ Tamurkhan&apos;s power cannot save him if he is destroyed by an attack which cau
           <modifiers>
             <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category"/>
             <modifier type="remove" value="fc26-7737-f7cb-8977" field="category"/>
-            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries"/>
-            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
+            <modifier type="set-primary" value="b876-2856-f1c2-c4f0" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
           </modifiers>
           <conditions>
-            <condition type="equalTo" value="1" field="selections" scope="root-entry" childId="a696-9ce8-c2ba-5461" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+            <condition type="atLeast" value="1" field="selections" scope="roster" childId="a696-9ce8-c2ba-5461" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="true"/>
           </conditions>
         </modifierGroup>
       </modifierGroups>
@@ -15546,20 +15546,24 @@ Tamurkhan&apos;s power cannot save him if he is destroyed by an attack which cau
       </selectionEntryGroups>
       <modifierGroups>
         <modifierGroup type="and">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="roster" childId="67de-5882-a257-da2e" shared="true" includeChildSelections="true" includeChildForces="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="476b-56ed-5973-3b8c" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
           <modifiers>
-            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries"/>
-            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries"/>
             <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category"/>
             <modifier type="remove" value="0eb4-f376-7725-b05b" field="category"/>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
           </modifiers>
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="roster" childId="67de-5882-a257-da2e" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="set-primary" value="fc26-7737-f7cb-8977" field="category" affects="self.entries.recursive"/>
+            <modifier type="remove" value="0eb4-f376-7725-b05b" field="category" affects="self.entries.recursive"/>
+          </modifiers>
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="roster" childId="476b-56ed-5973-3b8c" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
         </modifierGroup>
       </modifierGroups>
     </entryLink>


### PR DESCRIPTION
if you have a special character, which swaps units around permanently, the modifyer have to be differently. :
remove category [old]
set-primary category [new]
remove category [old] in self.entries
set-primary category [new] self.entries

The first two are needed to swap them in the roster itself. without them, it would only swap AFTER picking the unit. 

the latter two are needed to include all the ewuipment. without them, any costing equipment would still count as the old category.


